### PR TITLE
FEAT: Add exercise title field

### DIFF
--- a/.strigo/config.yml
+++ b/.strigo/config.yml
@@ -3,19 +3,24 @@
 classes:
   # `class_id` is optional for configurations
   # with only one class per repository
-  - class_id: <your_class_id>
+  - class_id: "<your_class_id>"
     exercises:
       # `file` can be relative or absolute
       - file: "../hello-world/hello.md"
+        title: "Hello!"
       - file: "../hello-world/world.md"
-  - class_id: <your_class_id>
+        title: "World!"
+  - class_id: "<your_class_id>"
     exercises:
       # `syntax` is optional
       # can be "md" | "rst" | "adoc"
       # uses file extension as fallback
       - file: "../markup-syntaxes/markdown.md"
         syntax: "md"
+        title: "Markdown!"
       - file: "../markup-syntaxes/restructured.rst"
         syntax: "rst"
+        title: "Restructed"
       - file: "../markup-syntaxes/asciidoc.adoc"
         syntax: "adoc"
+        title: "ASCII doc"


### PR DESCRIPTION
We don't have enough time to extract the title from the markup text alone, so we'll need users to let us know how to name their exercises.