### PR TITLE
Add aside info blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,28 @@
       ```
    1. Info block
       
-      You can add informative blocks of type `Positive`, `Negative` or `Neutral` anywhere in your Markdown exercise file:
+      You can add informative blocks of type `Positive`, `Negative` or `Neutral` anywhere in your Markdown exercise file (old and new syntax, both supported):
       ```md
       Positive
-      : This will appear in a Positive info box.
-      
+      : This will appear in a Positive info box (old syntax).
+
+      > aside positive
+      >
+      > This will appear in a Positive info box (new syntax).
+
       Neutral
-      : This will appear in a Neutral info box.
-      
+      : This will appear in a Neutral info box (old syntax).
+
+      > aside neutral
+      >
+      > This will appear in a Neutral info box (new syntax).
+
       Negative
-      : This will appear in a Negative info box.
+      : This will appear in a Negative info box (old syntax).
+
+      > aside negative
+      >
+      > This will appear in a Negative info box (new syntax).
       ```
 
    1. Frontmatter attributes

--- a/markup-syntaxes/markdown-extended.md
+++ b/markup-syntaxes/markdown-extended.md
@@ -4,13 +4,25 @@
 Duration: 1:30:00
 
 Positive
-: This will appear in a Positive info box.
+: This will appear in a Positive info box (old syntax).
+
+> aside positive
+>
+> This will appear in a Positive info box (new syntax).
 
 Neutral
-: This will appear in a Neutral info box.
+: This will appear in a Neutral info box (old syntax).
+
+> aside neutral
+>
+> This will appear in a Neutral info box (new syntax).
 
 Negative
-: This will appear in a Negative info box.
+: This will appear in a Negative info box (old syntax).
+
+> aside negative
+>
+> This will appear in a Negative info box (new syntax).
 
 ## Lorem ipsum
 Duration: 2:30:00


### PR DESCRIPTION
## Context

Users can now add informative blocks of type `Positive`, `Negative` or `Neutral` anywhere in their Markdown exercise files (old and new syntax, both supported):
```
Positive
: This will appear in a Positive info box (old syntax).

> aside positive
>
> This will appear in a Positive info box (new syntax).

Neutral
: This will appear in a Neutral info box (old syntax).

> aside neutral
>
> This will appear in a Neutral info box (new syntax).

Negative
: This will appear in a Negative info box (old syntax).

> aside negative
>
> This will appear in a Negative info box (new syntax).
```

![image](https://github.com/strigo/foundation/assets/6122352/3f4349b9-ac72-4c20-82a2-6df2fbf8fb33)

